### PR TITLE
fix the hess VO definition

### DIFF
--- a/manifests/vo_hess_experiment_eu.pp
+++ b/manifests/vo_hess_experiment_eu.pp
@@ -1,5 +1,5 @@
 class voms::vo_hess_experiment_eu {
-  voms::client{'vo.hess_experiment.eu':
+  voms::client{'vo.hess-experiment.eu':
     servers => [
       {
         server => 'grid12.lal.in2p3.fr',


### PR DESCRIPTION
dashes in the VO details, and undersccores in the puppet class name.
This is because puppet class names do not support dashes, nor dots, and those damn vo names contain all of them.
