### PR TITLE
Remove obsolete (lcg-)voms.cern.ch servers

### DIFF
--- a/manifests/alice.pp
+++ b/manifests/alice.pp
@@ -15,17 +15,7 @@
 
 class voms::alice {
   voms::client{'alice':
-      servers  => [{server => 'voms.cern.ch',
-                    port   => '15000',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'lcg-voms.cern.ch',
-                    port   => '15000',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'voms2.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15000',
                     dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
                     ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'

--- a/manifests/atlas.pp
+++ b/manifests/atlas.pp
@@ -15,17 +15,7 @@
 
 class voms::atlas {
   voms::client{'atlas':
-      servers  => [{server => 'voms.cern.ch',
-                    port   => '15001',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'lcg-voms.cern.ch',
-                    port   => '15001',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'voms2.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15001',
                     dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
                     ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'

--- a/manifests/cms.pp
+++ b/manifests/cms.pp
@@ -15,17 +15,7 @@
 
 class voms::cms {
   voms::client{'cms':
-      servers  => [{server => 'voms.cern.ch',
-                    port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'lcg-voms.cern.ch',
-                    port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'voms2.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15002',
                     dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
                     ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'

--- a/manifests/lhcb.pp
+++ b/manifests/lhcb.pp
@@ -15,17 +15,7 @@
 
 class voms::lhcb {
   voms::client{'lhcb':
-      servers  => [{server => 'voms.cern.ch',
-                    port   => '15003',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'lcg-voms.cern.ch',
-                    port   => '15003',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'voms2.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15003',
                     dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
                     ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'

--- a/manifests/ops.pp
+++ b/manifests/ops.pp
@@ -15,17 +15,7 @@
 
 class voms::ops {
   voms::client{'ops':
-      servers  => [{server => 'voms.cern.ch',
-                    port   => '15009',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'lcg-voms.cern.ch',
-                    port   => '15009',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
-                   },
-                   {server => 'voms2.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15009',
                     dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
                     ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'


### PR DESCRIPTION
The old servers should be removed to avoid timeouts and error messages.