### PR TITLE
GridPP Approved VO Changes to 22/4/16

### DIFF
--- a/.project
+++ b/.project
@@ -3,6 +3,8 @@
 	<name>puppet-voms</name>
 	<comment></comment>
 	<projects>
+		<project>external-mysql</project>
+		<project>external-stdlib</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>

--- a/README.md
+++ b/README.md
@@ -11,23 +11,23 @@ Create files for the voms-proxy-init and voms-proxy-validate.
 
      voms::client{'MyVO':
         vo       => 'MyVO',
-        servers  => [{server => 'voms.cern.ch',
+        servers  => [{server => 'voms2.cern.ch',
                       port   => '15009',
-                      dn     => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                      ca_dn  => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                      dn     => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                      ca_dn  => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                      },
-                     {server => 'lcg-voms.cern.ch',
+                     {server => 'lcg-voms2.cern.ch',
                       port   => '15009',
-                       dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                       ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                       dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                       ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                      }]
 
  The above declaration will create the files:
 
-     /etc/vomses/MyVO/voms.cern.ch
+     /etc/vomses/MyVO/voms2.cern.ch
  and
 
-     /etc/grid-security/vomsdir/MyVO/voms.cern.ch.lsc
+     /etc/grid-security/vomsdir/MyVO/voms2.cern.ch.lsc
 
 
  For some VOs, you can probably find a predefined class to enable a

--- a/manifests/aleph.pp
+++ b/manifests/aleph.pp
@@ -15,15 +15,15 @@
 
 class voms::aleph {
   voms::client{'vo.aleph.cern.ch':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
                   ]
   }

--- a/manifests/cdf.pp
+++ b/manifests/cdf.pp
@@ -16,8 +16,8 @@ class voms::cdf {
       {
         server => 'voms.fnal.gov',
           port => '15020',
-            dn => '/DC=org/DC=doegrids/OU=Services/CN=http/voms.fnal.gov',
-         ca_dn => '/DC=org/DC=DOEGrids/OU=Certificate Authorities/CN=DOEGrids CA 1',
+            dn => '/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.fnal.gov',
+         ca_dn => '/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1',
       },
     ]
   }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -18,15 +18,15 @@
 # == Example
 #
 #     voms::client{'ops':
-#        servers  => [{server => 'voms.cern.ch',
+#        servers  => [{server => 'voms2.cern.ch',
 #                   port   => '15009',
-#                   dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-#                   ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+#                   dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+#                   ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
 #                  },
-#                  {server => 'lcg-voms.cern.ch',
+#                  {server => 'lcg-voms2.cern.ch',
 #                   port   => '15009',
-#                   dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-#                   ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+#                   dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+#                   ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
 #                  }]
 #
 # == Authors

--- a/manifests/comet_j_parc_jp.pp
+++ b/manifests/comet_j_parc_jp.pp
@@ -1,0 +1,24 @@
+class voms::comet_j_parc_jp {
+  voms::client{'comet.j-parc.jp':
+    servers => [
+      {
+        server => 'voms.gridpp.ac.uk',
+          port => '15005',
+            dn => '/C=UK/O=eScience/OU=Manchester/L=HEP/CN=voms.gridpp.ac.uk',
+         ca_dn => '/C=UK/O=eScienceCA/OU=Authority/CN=UK e-Science CA 2B',
+      },
+      {
+        server => 'voms02.gridpp.ac.uk',
+          port => '15005',
+            dn => '/C=UK/O=eScience/OU=Oxford/L=OeSC/CN=voms02.gridpp.ac.uk',
+         ca_dn => '/C=UK/O=eScienceCA/OU=Authority/CN=UK e-Science CA 2B',
+      },
+      {
+        server => 'voms03.gridpp.ac.uk',
+          port => '15005',
+            dn => '/C=UK/O=eScience/OU=Imperial/L=Physics/CN=voms03.gridpp.ac.uk',
+         ca_dn => '/C=UK/O=eScienceCA/OU=Authority/CN=UK e-Science CA 2B',
+      },         
+    ]
+  }
+}

--- a/manifests/delphi.pp
+++ b/manifests/delphi.pp
@@ -15,15 +15,15 @@
 
 class voms::delphi {
   voms::client{'vo.delphi.cern.ch':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
                   ]
   }

--- a/manifests/dzero.pp
+++ b/manifests/dzero.pp
@@ -4,8 +4,8 @@ class voms::dzero {
       {
         server => 'voms.fnal.gov',
           port => '15002',
-            dn => '/DC=org/DC=doegrids/OU=Services/CN=http/voms.fnal.gov',
-         ca_dn => '/DC=org/DC=DOEGrids/OU=Certificate Authorities/CN=DOEGrids CA 1',
+            dn => '/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.fnal.gov',
+         ca_dn => '/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1',
       },
     ]
   }

--- a/manifests/envirogrids.pp
+++ b/manifests/envirogrids.pp
@@ -16,15 +16,15 @@
 #unfortunately the full VO name envirogrids.vo.eu-egee.org is not a valid class name...
 class voms::envirogrids {
   voms::client{'envirogrids.vo.eu-egee.org':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15002',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    }]
  }
 }

--- a/manifests/geant4.pp
+++ b/manifests/geant4.pp
@@ -15,15 +15,15 @@
 
 class voms::geant4 {
   voms::client{'geant4':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15007',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15007',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    }]
  }
 }

--- a/manifests/gear.pp
+++ b/manifests/gear.pp
@@ -16,15 +16,15 @@
 #unfortunately the full VO name vo.gear.cern.ch is not a valid class name...
 class voms::gear {
   voms::client{'vo.gear.cern.ch':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15008',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15008',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    }]
  }
 }

--- a/manifests/l3.pp
+++ b/manifests/l3.pp
@@ -15,15 +15,15 @@
 
 class voms::l3 {
   voms::client{'vo.l3.cern.ch':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15015',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15015',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
                   ]
   }

--- a/manifests/lsst.pp
+++ b/manifests/lsst.pp
@@ -4,20 +4,20 @@ class voms::lsst {
       {
         server => 'voms.fnal.gov',
           port => '15003',
-            dn => '/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms.fnal.gov',
-         ca_dn => '/DC=com/DC=DigiCert-Grid/O=DigiCert Grid/CN=DigiCert Grid CA-1',
+            dn => '/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.fnal.gov',
+         ca_dn => '/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1',
       },
       {
         server => 'voms2.fnal.gov',
           port => '15003',
-            dn => '/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov',
+            dn => '/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms1.fnal.gov',
          ca_dn => '/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1',
       },
       {
         server => 'voms1.fnal.gov',
           port => '15003',
             dn => '/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms1.fnal.gov',
-         ca_dn => '/DC=com/DC=DigiCert-Grid/O=DigiCert Grid/CN=DigiCert Grid CA-1',
+         ca_dn => '/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1',
       },
 
     ]

--- a/manifests/lsst.pp
+++ b/manifests/lsst.pp
@@ -10,8 +10,8 @@ class voms::lsst {
       {
         server => 'voms2.fnal.gov',
           port => '15003',
-            dn => '/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov',
-         ca_dn => '/DC=com/DC=DigiCert-Grid/O=DigiCert Grid/CN=DigiCert Grid CA-1',
+            dn => '/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov',
+         ca_dn => '/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1',
       },
       {
         server => 'voms1.fnal.gov',

--- a/manifests/lz.pp
+++ b/manifests/lz.pp
@@ -1,0 +1,12 @@
+class voms::lz {
+  voms::client{'lz':
+    servers => [
+      {
+        server => 'voms.hep.wisc.edu',
+          port => '15001',
+            dn => '/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms.hep.wisc.edu',
+         ca_dn => '/DC=com/DC=DigiCert-Grid/O=DigiCert Grid/CN=DigiCert Grid CA-1',
+      },
+    ]
+  }
+}

--- a/manifests/magic.pp
+++ b/manifests/magic.pp
@@ -10,8 +10,8 @@ class voms::magic {
       {
         server => 'voms02.pic.es',
           port => '15003',
-            dn => '/DC=es/DC=irisgrid/O=pic/CN=voms02.pic.es',
-         ca_dn => '/DC=es/DC=irisgrid/CN=IRISGridCA',
+            dn => '/DC=org/DC=terena/DC=tcs/C=ES/ST=Barcelona/L=Bellaterra/O=Port dInformacio Cientifica/CN=voms02.pic.es',
+         ca_dn => '/C=NL/ST=Noord-Holland/L=Amsterdam/O=TERENA/CN=TERENA eScience SSL CA 3',
       },
     ]
   }

--- a/manifests/magic.pp
+++ b/manifests/magic.pp
@@ -1,0 +1,18 @@
+class voms::magic {
+  voms::client{'magic':
+    servers => [
+      {
+        server => 'voms01.pic.es',
+          port => '15003',
+            dn => '/DC=org/DC=terena/DC=tcs/C=ES/ST=Barcelona/L=Bellaterra/O=Port dInformacio Cientifica/CN=voms01.pic.es',
+         ca_dn => '/C=NL/ST=Noord-Holland/L=Amsterdam/O=TERENA/CN=TERENA eScience SSL CA 3',
+      },
+      {
+        server => 'voms02.pic.es',
+          port => '15003',
+            dn => '/DC=es/DC=irisgrid/O=pic/CN=voms02.pic.es',
+         ca_dn => '/DC=es/DC=irisgrid/CN=IRISGridCA',
+      },
+    ]
+  }
+}

--- a/manifests/mice.pp
+++ b/manifests/mice.pp
@@ -16,7 +16,7 @@ class voms::mice {
       {
         server => 'voms03.gridpp.ac.uk',
           port => '15001',
-            dn => '/C=UK/O=eScience/OU=Imperial/L=Physics/CN=voms03.gridpp.ac.uk ',
+            dn => '/C=UK/O=eScience/OU=Imperial/L=Physics/CN=voms03.gridpp.ac.uk',
          ca_dn => '/C=UK/O=eScienceCA/OU=Authority/CN=UK e-Science CA 2B',
       },         
     ]

--- a/manifests/na48.pp
+++ b/manifests/na48.pp
@@ -15,15 +15,15 @@
 
 class voms::na48 {
   voms::client{'na48':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15009',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15009',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    }]
  }
 }

--- a/manifests/opal.pp
+++ b/manifests/opal.pp
@@ -15,15 +15,15 @@
 
 class voms::opal {
   voms::client{'vo.opal.cern.ch':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15016',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15016',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
                   ]
   }

--- a/manifests/planck.pp
+++ b/manifests/planck.pp
@@ -5,7 +5,7 @@ class voms::planck {
         server => 'voms.cnaf.infn.it',
           port => '15002',
             dn => '/C=IT/O=INFN/OU=Host/L=CNAF/CN=voms.cnaf.infn.it',
-         ca_dn => '/C=IT/O=INFN/CN=INFN CA',
+         ca_dn => '/C=IT/O=INFN/CN=INFN Certification Authority',
       },
     ]
   }

--- a/manifests/sixt.pp
+++ b/manifests/sixt.pp
@@ -16,15 +16,15 @@
 #unfortunately the full VO name vo.sixt.cern.ch is not a valid class name...
 class voms::sixt {
   voms::client{'vo.sixt.cern.ch':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15005',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15005',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    }]
  }
 }

--- a/manifests/unosat.pp
+++ b/manifests/unosat.pp
@@ -15,15 +15,15 @@
 
 class voms::unosat {
   voms::client{'unosat':
-      servers  => [{server => 'voms.cern.ch',
+      servers  => [{server => 'voms2.cern.ch',
                     port   => '15006',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    },
-                   {server => 'lcg-voms.cern.ch',
+                   {server => 'lcg-voms2.cern.ch',
                     port   => '15006',
-                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms.cern.ch',
-                    ca_dn => '/DC=ch/DC=cern/CN=CERN Trusted Certification Authority'
+                    dn    => '/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch',
+                    ca_dn => '/DC=ch/DC=cern/CN=CERN Grid Certification Authority'
                    }]
  }
 }

--- a/manifests/vo_southgrid_ac_uk.pp
+++ b/manifests/vo_southgrid_ac_uk.pp
@@ -16,7 +16,7 @@ class voms::vo_southgrid_ac_uk {
       {
         server => 'voms03.gridpp.ac.uk',
           port => '15019',
-            dn => '/C=UK/O=eScience/OU=Imperial/L=Physics/CN=voms03.gridpp.ac.uk ',
+            dn => '/C=UK/O=eScience/OU=Imperial/L=Physics/CN=voms03.gridpp.ac.uk',
          ca_dn => '/C=UK/O=eScienceCA/OU=Authority/CN=UK e-Science CA 2B',
       },         
     ]


### PR DESCRIPTION
Hi,

I've added all the VOs we support at RAL PPD and updated all the VOMS server DNs and CA DNs I could find.

I think the way forward for this is to define a hash somewhere with all the know voms services in it:

{ 'voms.example.com' =>
                                         { 
                                            dn        => '/DC=...',
                                            ca_dn  => '/DC=...'
                                         },
   'othervoms.somewhereelse.edu' =>
                                        {
  ...
                                        }
}

Then have that referenced by the individual VO classes (or the voms::client class) so for each VO you only need to specify the VOMS server and port and we only need to maintain the list of DNs and CA_DNs in one place.

I'll start work on it when I get a chance.

Yours,
Chris Brew