### PR TITLE
Use small class name in Class for puppet 5

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -72,7 +72,7 @@ define voms::admin($vo=$name,
        ensure_resource('class','voms::admin::install')
        ensure_resource('class','voms::admin::config')
        ensure_resource('class','voms::admin::service')
-       Class[Voms::Admin::Install] -> Class[Voms::Admin::Config] -> Voms::Admin[$vo] -> Class[Voms::Admin::Service]
+       Class[voms::admin::install] -> Class[voms::admin::config] -> Voms::Admin[$vo] -> Class[voms::admin::service]
 
 
        file{"/etc/voms-admin-puppet/voms-admin-add-admin-${vo}.sh":

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,7 +36,7 @@
 #
 define voms::client ($vo = $name, $servers = []  ) {
    ensure_resource('class','voms::install')
-   Class[Voms::Install] -> Voms::Client[$vo]
+   Class[voms::install] -> Voms::Client[$vo]
 
    file {"/etc/grid-security/vomsdir/${vo}":
                    ensure  => directory,

--- a/manifests/core.pp
+++ b/manifests/core.pp
@@ -53,7 +53,7 @@ define voms::core($vo=$name,
        ensure_resource('class',"voms::${vo}")
        ensure_resource('class','voms::core::install')
        ensure_resource('class','voms::core::service')
-       Class[Voms::Core::Install] -> Voms::Core[$vo] -> Class[Voms::Core::Service]
+       Class[voms::core::install] -> Voms::Core[$vo] -> Class[voms::core::service]
 
        file{"/etc/voms/${vo}":
          ensure  => directory,


### PR DESCRIPTION
Capital class name is deprecated in puppet 5.

ref: https://tickets.puppetlabs.com/browse/PUP-6084